### PR TITLE
Fix turbo-vision mouse-drag scroll vanishing bug (negative delta clamp)

### DIFF
--- a/src/views/editor.rs
+++ b/src/views/editor.rs
@@ -623,6 +623,9 @@ impl Editor {
             self.delta.x = self.cursor.x - width + 1;
         }
 
+        self.delta.x = self.delta.x.max(0);
+        self.delta.y = self.delta.y.max(0);
+
         self.update_scrollbars();
         self.update_indicator();
     }

--- a/src/views/memo.rs
+++ b/src/views/memo.rs
@@ -198,6 +198,9 @@ impl Memo {
             self.delta.x = self.cursor.x - width + 1;
         }
 
+        self.delta.x = self.delta.x.max(0);
+        self.delta.y = self.delta.y.max(0);
+
         self.update_scrollbars();
     }
 


### PR DESCRIPTION
This should fix a bug where dragging with the mouse inside an editor window can make the text disappear forever, until the editor window is closed and reopened.